### PR TITLE
Filter events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@
 
 # 0.2.1
 - Fix: Remove wrappedJSObject circular object from event duration object
+
+# 0.2.2
+- Fix: Filter out recurring event occurrences from the past in `.getEventsByTime()`
+- Fix: CalDav saves the end date of all day events as the start of the next day. To fix this, we now subtract one second from the end date.

--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -89,7 +89,9 @@ function createCalendar(request) {
 
             const xmlRequest = byTimeTemplate({ start, end });
 
-            return request(this.config, "REPORT", 1, xmlRequest).then(xmlParser.parseEvents);
+            return request(this.config, "REPORT", 1, xmlRequest)
+                .then(xmlParser.parseEvents)
+                .then(events => events.filter(event => moment(event.data.start).isSameOrAfter(start, "day")));
         }
     }
 

--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -3,6 +3,7 @@
 const parseXMLString = require("xml2js").parseString;
 const nodefn = require("when/node");
 const ICAL = require("ical.js");
+const moment = require("moment");
 
 // parse calendar object
 function parseCalendarMultistatus(xml) {
@@ -76,10 +77,19 @@ function getNormalizedDuration(dtstart, dtend) {
     return duration;
 }
 
+function getNormalizedEndDate(endDate, duration) {
+    const allDayEvent = duration.days > 0 || duration.weeks > 0;
+
+    // CalDav saves the end date of all day events as the start of the next day
+    // To fix this, we subtract one second from the end date
+    return allDayEvent ? moment(endDate).subtract(1, "seconds").toISOString() : endDate;
+}
+
 function getNormalOccurenceEventData(nextEvent, eventData, vevent) {
     const dtstart = nextEvent.startDate;
     const dtend = nextEvent.endDate;
     const { summary: title, uid, location, description } = nextEvent.item;
+    const duration = getNormalizedDuration(dtstart, dtend);
 
     return {
         title,
@@ -87,8 +97,8 @@ function getNormalOccurenceEventData(nextEvent, eventData, vevent) {
         location,
         description,
         start: new Date(dtstart),
-        end: new Date(dtend),
-        duration: getNormalizedDuration(dtstart, dtend),
+        end: getNormalizedEndDate(new Date(dtend), duration),
+        duration,
         type: { recurring: true, edited: false },
         createdAt: new Date(vevent.getFirstPropertyValue("created"))
     };
@@ -97,6 +107,7 @@ function getNormalOccurenceEventData(nextEvent, eventData, vevent) {
 function getModifiedOccurenceEventData(vevent, eventData) {
     const dtstart = vevent.getFirstPropertyValue("dtstart");
     const dtend = vevent.getFirstPropertyValue("dtend");
+    const duration = getNormalizedDuration(dtstart, dtend);
 
     return {
         title: vevent.getFirstPropertyValue("summary"),
@@ -104,8 +115,8 @@ function getModifiedOccurenceEventData(vevent, eventData) {
         location: vevent.getFirstPropertyValue("location"),
         description: vevent.getFirstPropertyValue("description"),
         start: new Date(dtstart),
-        end: new Date(dtend),
-        duration: getNormalizedDuration(dtstart, dtend),
+        end: getNormalizedEndDate(new Date(dtend), duration),
+        duration,
         type: { recurring: true, edited: true },
         createdAt: new Date(vevent.getFirstPropertyValue("created"))
     };
@@ -200,6 +211,7 @@ function parseEvents(xml) {
                 // It could be a multiple day event or a single day event
                 const dtstart = vevent.getFirstPropertyValue("dtstart");
                 const dtend = vevent.getFirstPropertyValue("dtend");
+                const duration = getNormalizedDuration(dtstart, dtend);
 
                 eventData = {
                     title: vevent.getFirstPropertyValue("summary"),
@@ -207,8 +219,8 @@ function parseEvents(xml) {
                     location: vevent.getFirstPropertyValue("location"),
                     description: vevent.getFirstPropertyValue("description"),
                     start: new Date(dtstart),
-                    end: new Date(dtend),
-                    duration: getNormalizedDuration(dtstart, dtend),
+                    end: getNormalizedEndDate(new Date(dtend), duration),
+                    duration,
                     type: { recurring: false, edited: false },
                     createdAt: new Date(vevent.getFirstPropertyValue("created"))
                 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapegoat",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "fetches calendar/event objects from a CalDav server",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
Update Scrapegoat to filter out recurring event occurrences from the past in `.getEventsByTime()`