### PR TITLE
Add organizer to event data.

### DIFF
--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -100,7 +100,8 @@ function getNormalOccurenceEventData(nextEvent, eventData, vevent) {
         end: getNormalizedEndDate(new Date(dtend), duration),
         duration,
         type: { recurring: true, edited: false },
-        createdAt: new Date(vevent.getFirstPropertyValue("created"))
+        createdAt: new Date(vevent.getFirstPropertyValue("created")),
+        organizer: getOrganizer(vevent)
     };
 }
 
@@ -118,8 +119,17 @@ function getModifiedOccurenceEventData(vevent, eventData) {
         end: getNormalizedEndDate(new Date(dtend), duration),
         duration,
         type: { recurring: true, edited: true },
-        createdAt: new Date(vevent.getFirstPropertyValue("created"))
+        createdAt: new Date(vevent.getFirstPropertyValue("created")),
+        organizer: getOrganizer(vevent)
     };
+}
+
+function getOrganizer(vevent) {
+    let organizer = vevent.getFirstProperty("organizer").getParameter("cn")
+    if (!organizer) {
+        organizer = vevent.getFirstPropertyValue("organizer");
+    }
+    return organizer;
 }
 
 function parseEvents(xml) {
@@ -222,7 +232,8 @@ function parseEvents(xml) {
                     end: getNormalizedEndDate(new Date(dtend), duration),
                     duration,
                     type: { recurring: false, edited: false },
-                    createdAt: new Date(vevent.getFirstPropertyValue("created"))
+                    createdAt: new Date(vevent.getFirstPropertyValue("created")),
+                    organizer: getOrganizer(vevent)
                 };
 
                 formatted.push({


### PR DESCRIPTION
Event data lacks the organizer field. Here's the attempt to add it.