### PR TITLE
Fix: Convert dates to ISO-Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,18 @@
 # 0.3.0
 - Feature: An optional `timeout` parameter can be provided to the `config` object passed to `Scrapegoat` to indicate the number of milliseconds to wait for the server to send the response before aborting the request.
 
+# 0.4.0
+- fix(parser): convert dates to ISO-Strings
+
+    Return all dates (`start`, `end`, and `createdAt`) as ISO-Strings,
+    instead of Date objects to maintain consistency.
+
+    BREAKING CHANGE:
+
+    The dates were returned as a mix of ISO-Strings and Date Objects
+    in previous versions.
+
+    To migrate your project, confirm that you are handling the dates
+    received from scrapegoat correctly.
+- fix(parser): remove etag trailing double quote
+- docs(readme): update docs on README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,17 +28,11 @@
 - Feature: An optional `timeout` parameter can be provided to the `config` object passed to `Scrapegoat` to indicate the number of milliseconds to wait for the server to send the response before aborting the request.
 
 # 0.4.0
-- fix(parser): convert dates to ISO-Strings
-
-    Return all dates (`start`, `end`, and `createdAt`) as ISO-Strings,
-    instead of Date objects to maintain consistency.
+- Fix: Convert `start`, `end`, and `createdAt` dates to ISO-Strings instead of Date objects to maintain consistency.
 
     BREAKING CHANGE:
 
-    The dates were returned as a mix of ISO-Strings and Date Objects
-    in previous versions.
+    The dates were returned as a mix of ISO-Strings and Date Objects in previous versions.
 
-    To migrate your project, confirm that you are handling the dates
-    received from scrapegoat correctly.
-- fix(parser): remove etag trailing double quote
-- docs(readme): update docs on README.md
+    To migrate your project, confirm that you are handling the dates received from scrapegoat correctly.
+- Fix: Remove `etag` trailing double quote

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ Output should be something like this:
 [
     {
         ics: '/cal.php/calendars/test/holidays/1234564316516.ics',
-        etag: 'fc46dd304e83f572688c68ab63816c8f"',
+        etag: 'fc46dd304e83f572688c68ab63816c8f',
         data: {
             title: 'Holiday: John Doe',
             uid: '56ea42c0-e4af-4ac8-8d60-d95996c9ddc5',
             location: 'Kissing, Augsburg, Germany',
             description: null,
-            start: 2017-02-16T00:00:00.000Z,
-            end: 2017-02-18T00:00:00.000Z,
+            start: '2017-02-16T00:00:00.000Z',
+            end: '2017-02-18T00:00:00.000Z',
             duration: {
                 weeks: 0,
                 days: 2,
@@ -117,7 +117,7 @@ Output should be something like this:
                 isNegative: false
             },
             type: { recurring: false, edited: false },
-            createdAt: 2017-01-24T15:33:04.000Z
+            createdAt: '2017-01-24T15:33:04.000Z'
         }
     }
 ]

--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -82,7 +82,11 @@ function getNormalizedEndDate(endDate, duration) {
 
     // CalDav saves the end date of all day events as the start of the next day
     // To fix this, we subtract one second from the end date
-    return allDayEvent ? moment(endDate).subtract(1, "seconds").toISOString() : endDate;
+    return (
+        allDayEvent ?
+            new Date(moment(endDate).subtract(1, "seconds")) :
+            endDate
+    ).toISOString();
 }
 
 function getNormalOccurenceEventData(nextEvent, eventData, vevent) {
@@ -96,11 +100,11 @@ function getNormalOccurenceEventData(nextEvent, eventData, vevent) {
         uid,
         location,
         description,
-        start: new Date(dtstart),
+        start: new Date(dtstart).toISOString(),
         end: getNormalizedEndDate(new Date(dtend), duration),
         duration,
         type: { recurring: true, edited: false },
-        createdAt: new Date(vevent.getFirstPropertyValue("created"))
+        createdAt: new Date(vevent.getFirstPropertyValue("created")).toISOString()
     };
 }
 
@@ -114,11 +118,11 @@ function getModifiedOccurenceEventData(vevent, eventData) {
         uid: vevent.getFirstPropertyValue("uid"),
         location: vevent.getFirstPropertyValue("location"),
         description: vevent.getFirstPropertyValue("description"),
-        start: new Date(dtstart),
+        start: new Date(dtstart).toISOString(),
         end: getNormalizedEndDate(new Date(dtend), duration),
         duration,
         type: { recurring: true, edited: true },
-        createdAt: new Date(vevent.getFirstPropertyValue("created"))
+        createdAt: new Date(vevent.getFirstPropertyValue("created")).toISOString()
     };
 }
 
@@ -218,11 +222,11 @@ function parseEvents(xml) {
                     uid: vevent.getFirstPropertyValue("uid"),
                     location: vevent.getFirstPropertyValue("location"),
                     description: vevent.getFirstPropertyValue("description"),
-                    start: new Date(dtstart),
+                    start: new Date(dtstart).toISOString(),
                     end: getNormalizedEndDate(new Date(dtend), duration),
                     duration,
                     type: { recurring: false, edited: false },
-                    createdAt: new Date(vevent.getFirstPropertyValue("created"))
+                    createdAt: new Date(vevent.getFirstPropertyValue("created")).toISOString()
                 };
 
                 formatted.push({
@@ -234,8 +238,8 @@ function parseEvents(xml) {
         });
 
         formatted.sort((a, b) => {
-            const aStart = new ICAL.Time().fromJSDate(a.data.start);
-            const bStart = new ICAL.Time().fromJSDate(b.data.start);
+            const aStart = new ICAL.Time().fromJSDate(new Date(a.data.start));
+            const bStart = new ICAL.Time().fromJSDate(new Date(b.data.start));
 
             return aStart.compare(bStart);
         });

--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -39,7 +39,7 @@ function parseEventsMultistatus(xml) {
             // fix etag string (renders as '"[...]"', ugly xml2js objects (pew pew)
             let etag = event["d:propstat"][0]["d:prop"][0]["d:getetag"][0];
 
-            etag = etag.substring(1, etag.length - 1);
+            etag = stripDoubleQuotes(etag);
 
             formatted.push({
                 ics: event["d:href"][0],
@@ -49,6 +49,12 @@ function parseEventsMultistatus(xml) {
 
         return formatted;
     });
+}
+
+function stripDoubleQuotes(etag) {
+    // etag is wrapped in double quotes e.g "edbc0fe050fc096e444756252c94c590"
+    // returns etag without the double quotes
+    return etag.slice(1, -1);
 }
 
 function isModified(occurence, modifiedOccurances) {
@@ -140,7 +146,7 @@ function parseEvents(xml) {
         parsed.forEach((event) => {
             let etag = event["d:propstat"][0]["d:prop"][0]["d:getetag"][0];
 
-            etag = etag.substring(1, etag.length - 1);
+            etag = stripDoubleQuotes(etag);
 
             let eventData = {};
             const calendarData = event["d:propstat"][0]["d:prop"][0]["cal:calendar-data"][0];

--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -88,11 +88,9 @@ function getNormalizedEndDate(endDate, duration) {
 
     // CalDav saves the end date of all day events as the start of the next day
     // To fix this, we subtract one second from the end date
-    return (
-        allDayEvent ?
-            new Date(moment(endDate).subtract(1, "seconds")) :
-            endDate
-    ).toISOString();
+    return allDayEvent ?
+        moment(endDate).subtract(1, "seconds").toISOString() :
+        endDate.toISOString();
 }
 
 function getNormalOccurenceEventData(nextEvent, eventData, vevent) {

--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -39,7 +39,7 @@ function parseEventsMultistatus(xml) {
             // fix etag string (renders as '"[...]"', ugly xml2js objects (pew pew)
             let etag = event["d:propstat"][0]["d:prop"][0]["d:getetag"][0];
 
-            etag = etag.substring(1, etag.length);
+            etag = etag.substring(1, etag.length - 1);
 
             formatted.push({
                 ics: event["d:href"][0],
@@ -140,7 +140,7 @@ function parseEvents(xml) {
         parsed.forEach((event) => {
             let etag = event["d:propstat"][0]["d:prop"][0]["d:getetag"][0];
 
-            etag = etag.substring(1, etag.length);
+            etag = etag.substring(1, etag.length - 1);
 
             let eventData = {};
             const calendarData = event["d:propstat"][0]["d:prop"][0]["cal:calendar-data"][0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapegoat",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "fetches calendar/event objects from a CalDav server",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
- fix(parser): convert dates to ISO-Strings

    Return all dates (`start`, `end`, and `createdAt`) as ISO-Strings,
    instead of Date objects to maintain consistency.

    BREAKING CHANGE:

    The dates were returned as a mix of ISO-Strings and Date Objects
    in previous versions.

    To migrate your project, confirm that you are handling the dates
    received from scrapegoat correctly.
- fix(parser): remove etag trailing double quote
- docs(readme): update docs on README.md