### PR TITLE
Refactor: Compare JS dates without converting to `ICAL.Time`

### DIFF
--- a/lib/xml/parser.js
+++ b/lib/xml/parser.js
@@ -241,12 +241,8 @@ function parseEvents(xml) {
             }
         });
 
-        formatted.sort((a, b) => {
-            const aStart = new ICAL.Time().fromJSDate(new Date(a.data.start));
-            const bStart = new ICAL.Time().fromJSDate(new Date(b.data.start));
-
-            return aStart.compare(bStart);
-        });
+        // sort events by start date - ascending (older events first)
+        formatted.sort((a, b) => new Date(a.data.start).getTime() - new Date(b.data.start).getTime());
 
         return formatted;
     });


### PR DESCRIPTION
Changes:

* Compare JS dates without converting to `ICAL.Time`